### PR TITLE
Add repo link

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -2,4 +2,4 @@
 
 | Contributor names | Link to Github repository |
 | ----------------- | ------------------------- |
-|                   |                           |
+|  Arthur Apostel                 |  https://github.com/arthurapostel/nextflow-project/tree/master                         |


### PR DESCRIPTION
Hi! I've added the link to my repo to the overview table. I've been able to run the pipeline without any issues on Ghent University's HPC cluster.